### PR TITLE
Resolve ruby warnings before ArgumentError

### DIFF
--- a/lib/ach/field_identifiers.rb
+++ b/lib/ach/field_identifiers.rb
@@ -51,7 +51,7 @@ module ACH
           if RUBY_VERSION < '1.9'
             val = Iconv.conv('ASCII//IGNORE', 'UTF8', val)
           else
-            val = val.encode Encoding.find('ASCII'), ENCODING_OPTIONS
+            val = val.encode(Encoding.find('ASCII'), **ENCODING_OPTIONS)
           end
         end
 

--- a/spec/ach/field_identifiers_spec.rb
+++ b/spec/ach/field_identifiers_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe ACH::FieldIdentifiers do
+RSpec.describe ACH::FieldIdentifiers do
   describe 'setter' do
 
     before(:each) do
       @klass = Class.new(ACH::Records::Record)
       @klass.instance_variable_set(:@fields, [])
     end
-    
+
     it 'should validate against a Regexp' do
       @klass.field(:sample, String, nil, nil, /\A\w{5}\Z/)
       record = @klass.new
@@ -18,12 +18,12 @@ describe ACH::FieldIdentifiers do
       lambda { record.sample = 'abcde' }.should_not raise_error
       record.sample.should == 'abcde'
     end
-      
+
     it 'should validate against a Proc' do
       block = Proc.new do |val|
         [1, 2, 500].include?(val)
       end
-      
+
       @klass.field(:sample, String, nil, nil, block)
       record = @klass.new
       lambda { record.sample = 5 }.should raise_error(RuntimeError)
@@ -35,13 +35,12 @@ describe ACH::FieldIdentifiers do
       lambda { record.sample = 500 }.should_not raise_error
       record.sample.should == 500
     end
-    
+
     it 'should set instance variable' do
       @klass.field(:sample, String)
       record = @klass.new
       record.sample = 'abcde'
       record.instance_variable_get(:@sample).should == 'abcde'
     end
-
   end
 end


### PR DESCRIPTION
Resolve ruby warnings before ArgumentError
This is a breaking change for the upgrade to ruby 3.

Resolves:
```
[8] pry(#<ACH::Records::EntryDetail>)> val.encode(Encoding.find('ASCII'), ENCODING_OPTIONS)
(pry):8: warning: Using the last argument as keyword parameters is deprecated
=> "Employee Name That Is Much Too Long"
[9] pry(#<ACH::Records::EntryDetail>)> val.encode(Encoding.find('ASCII'), **ENCODING_OPTIONS)
=> "Employee Name That Is Much Too Long"
```